### PR TITLE
Add visa application status tracking

### DIFF
--- a/logger/logger.py
+++ b/logger/logger.py
@@ -58,7 +58,7 @@ def telegram(msg: str, *args, **kwargs):
     """Public function to send a single message via the 'public' Telegram bot."""
     text = msg.format(*args, **kwargs) if (args or kwargs) else msg
 
-    url = f"https://api.telegram.org/bot{os.getenv("TELEGRAM_BOT_TOKEN")}/sendMessage"
+    url = f'https://api.telegram.org/bot{os.getenv("TELEGRAM_BOT_TOKEN")}/sendMessage'
     payload = {"chat_id": os.getenv("TELEGRAM_CHAT_ID"), "text": text}
 
     try:

--- a/main.py
+++ b/main.py
@@ -23,13 +23,18 @@ if __name__ == "__main__":
     # Заполняем переменные окружения значениями по умолчанию, если они не заданы
     EnvironmentManager.fill_default_values()
 
-    # Планируем выполнение задачи
-    time_interval = os.getenv("CHECK_INTERVAL")
-    schedule.every(int(time_interval)).minutes.do(ScheduleManager.job)
+    print("\nВыберите режим работы:")
+    print("  1: Проверка слотов")
+    print("  2: Проверка статуса заявления")
+    choice = input("Ваш выбор (1-2): ").strip()
 
-    # Запускаем бесконечный цикл для обработки запланированных задач
-    while True:
-        schedule.run_pending()
-        # Проверяем, есть ли задачи, которые нужно выполнить в текущий момент
-        time.sleep(1)
-        # Ждём 1 секунду, чтобы не перегружать процессор
+    if choice == "1":
+        time_interval = os.getenv("CHECK_INTERVAL")
+        schedule.every(int(time_interval)).minutes.do(ScheduleManager.job, "availability")
+        while True:
+            schedule.run_pending()
+            time.sleep(1)
+    elif choice == "2":
+        ScheduleManager.job("status")
+    else:
+        print("Неверный выбор")

--- a/managers/schedule_manager.py
+++ b/managers/schedule_manager.py
@@ -22,8 +22,11 @@ from managers.process_manager import ProcessManager
 class ScheduleManager:
     # Основная задача, выполняемая по расписанию
     @staticmethod
-    def job():
-        info(f'Проверяем места в Almaviva г. {os.getenv("CITY_NAME")}')
+    def job(mode="availability"):
+        if mode == "availability":
+            info(f'Проверяем места в Almaviva г. {os.getenv("CITY_NAME")}')
+        else:
+            info('Проверяем статус заявления в Almaviva')
 
         pm = None
         # Подготовка ProcessManager для запуска процессов
@@ -34,8 +37,7 @@ class ScheduleManager:
             pm.start()
             # Создаем менеджера Almaviva для проверки мест
             almaviva = AlmavivaManager()
-            # Выполняем основной рабочий процесс проверки мест
-            almaviva.run()
+            almaviva.run(mode)
         # Игнорируем специфичные ошибки CDP при выполнении
         except CallMethodException as e:
             pass

--- a/services/telegram_service.py
+++ b/services/telegram_service.py
@@ -10,7 +10,7 @@ class TelegramService:
     @staticmethod
     def send_telegram_message(is_available):
         # Формируем заголовок push-уведомления
-        title = f"Almaviva в г. {os.getenv("CITY_NAME")}"
+        title = f'Almaviva в г. {os.getenv("CITY_NAME")}'
 
         # Если места доступны, готовим приоритетное уведомление
         if is_available:
@@ -23,5 +23,13 @@ class TelegramService:
         try:
             info("Отправили сообщение в телеграм")
             telegram(f"{title} - {body_text}")
+        except Exception as e:
+            raise Exception(f"Не удалось отправить сообщение в телеграм - ошибка: {e}")
+
+    @staticmethod
+    def send_status_message(text):
+        try:
+            info("Отправили сообщение в телеграм")
+            telegram(text)
         except Exception as e:
             raise Exception(f"Не удалось отправить сообщение в телеграм - ошибка: {e}")


### PR DESCRIPTION
## Summary
- support mapping Almaviva status codes to readable text
- enable checking and reporting application status
- allow choosing between slot availability check and status check at launch
- send generic Telegram messages for status

## Testing
- `python -m py_compile main.py managers/*.py services/*.py logger/*.py`

------
https://chatgpt.com/codex/tasks/task_e_688a553d1a00832e97325cc0b574341a